### PR TITLE
Make component types abstract

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,6 +2,37 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="HttpUrlsUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredUrls">
+        <list>
+          <option value="http://localhost" />
+          <option value="http://127.0.0.1" />
+          <option value="http://0.0.0.0" />
+          <option value="http://www.w3.org/" />
+          <option value="http://json-schema.org/draft" />
+          <option value="http://java.sun.com/" />
+          <option value="http://xmlns.jcp.org/" />
+          <option value="http://javafx.com/javafx/" />
+          <option value="http://javafx.com/fxml" />
+          <option value="http://maven.apache.org/xsd/" />
+          <option value="http://maven.apache.org/POM/" />
+          <option value="http://www.springframework.org/schema/" />
+          <option value="http://www.springframework.org/tags" />
+          <option value="http://www.springframework.org/security/tags" />
+          <option value="http://www.thymeleaf.org" />
+          <option value="http://www.jboss.org/j2ee/schema/" />
+          <option value="http://www.jboss.com/xml/ns/" />
+          <option value="http://www.ibm.com/webservices/xsd" />
+          <option value="http://activemq.apache.org/schema/" />
+          <option value="http://schema.cloudfoundry.org/spring/" />
+          <option value="http://schemas.xmlsoap.org/" />
+          <option value="http://cxf.apache.org/schemas/" />
+          <option value="http://primefaces.org/ui" />
+          <option value="http://tiles.apache.org/" />
+          <option value="http://www.apache.org" />
+        </list>
+      </option>
+    </inspection_tool>
     <inspection_tool class="JSMethodCanBeStatic" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSUnusedGlobalSymbols" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TypeScriptAbstractClassConstructorCanBeMadeProtected" enabled="false" level="WEAK WARNING" enabled_by_default="false" />

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -4,7 +4,7 @@
 
 [Components](https://en.wikipedia.org/wiki/Component_(graph_theory)) are the most fundamental part of Karambit. Each Component hosts a single graph of dependencies, and they expose the contract which Karambit implements during compilation.
 
-A component is a class marked with the `@Component` annotation. It's defined by its installed [Modules](#Modules), installed [Subcomponents](#Subcomponents), [scope](#Scope), [constructor arguments](#Component-dependencies), and [declared properties](#Exposing-types).
+A component is an abstract class marked with the `@Component` annotation. It's defined by its installed [Modules](#Modules), installed [Subcomponents](#Subcomponents), [scope](#Scope), [constructor arguments](#Component-dependencies), and [declared properties](#Exposing-types).
 
 ### Exposing types
 
@@ -13,12 +13,21 @@ A component with no properties has no use. A component ultimately exists to expo
 From the Hello World sample:
 ```typescript
 @Component(/* ... */)
-class HelloWorldComponent {
-    readonly greeter: Greeter
+abstract class HelloWorldComponent {
+    abstract readonly greeter: Greeter
 }
 ```
 
-This component exposes the `Greeter` type through its `greeter` property. Karambit will generate a graph of dependencies internally to satisfy `Greeter`'s dependencies, and then implement a getter that provides an instance of `Greeter`.
+This Component exposes the `Greeter` type through its `greeter` property. Karambit will generate a graph of dependencies internally to satisfy `Greeter`'s dependencies, and then implement a getter that provides an instance of `Greeter`.
+
+Karambit generates a new class that extends the class decorated with `@Component`. You can specify the name of the generated class via the `generateClassName` property of the Component options.
+
+To get an instance of this generated class, you can call `createComponent<typeof HelloWorldComponent>()`. Alternatively, you can get a reference to the generated constructor via `getConstructor(HelloWorldComponent)`:
+
+```typescript
+const HelloWorldComponentConstructor = getConstructor(HelloWorldComponent)
+const componentInstance = new HelloWorldComponentConstructor()
+```
 
 ### Component dependencies
 
@@ -35,7 +44,7 @@ interface MyComponentDependency {
 }
 
 @Component
-class MyComponent {
+abstract class MyComponent {
     constructor(dep: MyComponentDependency) { }
 }
 ```
@@ -54,7 +63,7 @@ Sometimes, you want to bind a single type into your graph rather than all of its
 
 ```typescript
 @Component
-class MyComponent {
+abstract class MyComponent {
     constructor(@BindsInstance value: number, @BindsInstance text: string) { }
 }
 ```
@@ -66,8 +75,9 @@ This is functionally equivalent to the previous example.
 Creating an instance of your dependency graph is simple, just call the constructor of your Component. You can access all of its properties just like any other class, and they will provide instances from the graph.
 
 From the Hello World sample:
+
 ```typescript
-const component = new HelloWorldComponent()
+const component = createComponent<typeof HelloWorldComponent>()
 console.log(component.greeter.greet()) // "Hello, World!"
 ```
 
@@ -102,8 +112,8 @@ In the Hello World sample, the `string` type is provided via a `@Provides` metho
 @Module
 abstract class HelloWorldModule {
     @Provides
-    static provideGreetingTarget(): string {
-        return "World"
+    static provideGreeting(): string {
+        return "Hello"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -78,9 +78,8 @@ The Component is what ultimately hosts a dependency graph, and how you expose th
 
 ```typescript
 @Component({modules: [HelloWorldModule]})
-class HelloWorldComponent {
-
-    readonly greeter: Greeter
+abstract class HelloWorldComponent {
+    abstract readonly greeter: Greeter
 }
 ```
 
@@ -99,9 +98,10 @@ In this sample, the `Greeter` class is marked `@Inject`, and this type is availa
 ```typescript
 @Inject
 class Greeter {
-
-    constructor(private readonly target: string) { }
-    /// the rest of the class body...
+    constructor(private readonly greeting: string) { }
+    greet(): string {
+        return `${this.greeting}, World!`
+    }
 }
 ```
 
@@ -118,8 +118,8 @@ In our example, the `string` type is provided in the `HelloWorldModule`:
 abstract class HelloWorldModule {
 
     @Provides
-    static provideGreetingTarget(): string {
-        return "World"
+    static provideGreeting(): string {
+        return "Hello"
     }
 }
 ```
@@ -136,20 +136,20 @@ Modules are installed in Components via the `modules` parameter of the `@Compone
 
 By providing the `string` type into our graph, all the required types are now satisfied with providers and Karambit can generate our Component implementation.
 
-You can use a Component by constructing it and accessing its properties just like any other class:
+You can instantiate a Component by calling `createComponent`, and access its properties just like any other class instance:
 
 ```typescript
-const component = new HelloWorldComponent()
+const component: HelloWorldComponent = createComponent<typeof HelloWorldComponent>()
 console.log(component.greeter.greet()) // "Hello, World!"
 ```
 
 Under the hood, Karambit has generated this implementation in the output JavaScript source:
 
 ```javascript
-class HelloWorldComponent {
+class KarambitHelloWorldComponent extends HelloWorldComponent {
     get greeter() { return this.getGreeter_1(); }
     getGreeter_1() { return new Greeter(this.getString_1()); }
-    getString_1() { return HelloWorldModule.provideGreetingTarget(); }
+    getString_1() { return HelloWorldModule.provideGreeting(); }
 }
 ```
 

--- a/integration/test/InjectTest.ts
+++ b/integration/test/InjectTest.ts
@@ -16,6 +16,7 @@ import {
     IntoSet,
     IntoMap,
     MapKey,
+    createComponent,
 } from "karambit-inject"
 
 describe("Injection", () => {
@@ -242,24 +243,24 @@ type NullableClass = InjectClass | null
 
 @Component({modules: [ScopeModule]})
 @TestScope
-class ScopedComponent {
+abstract class ScopedComponent {
 
-    readonly unscopedClass: UnscopedClass
+    abstract readonly unscopedClass: UnscopedClass
 
-    readonly scopedClass: ScopedClass
+    abstract readonly scopedClass: ScopedClass
 
-    readonly unscopedInjectClass: InjectClass
+    abstract readonly unscopedInjectClass: InjectClass
 
-    readonly scopedInjectClass: ScopedInjectClass
+    abstract readonly scopedInjectClass: ScopedInjectClass
 
-    readonly reusableInjectClass: ReusableInjectClass
+    abstract readonly reusableInjectClass: ReusableInjectClass
 
-    readonly reusableClass: ReusableClass
+    abstract readonly reusableClass: ReusableClass
 
-    readonly nullableClass: NullableClass
+    abstract readonly nullableClass: NullableClass
 }
 
-const scopedComponent = new ScopedComponent()
+const scopedComponent = createComponent<typeof ScopedComponent>()
 
 class ChildClass { }
 
@@ -382,22 +383,22 @@ interface ParentClassInterface {
 }
 
 @Component({modules: [ParentModule], subcomponents: [ChildSubcomponent, ScopedSubcomponent]})
-class ParentComponent {
+abstract class ParentComponent {
 
     constructor(child: ChildComponent, typeLiteralChild: {value: symbol}, @BindsInstance public boundString: string) { }
 
-    readonly value: symbol
-    readonly parentClass: ParentClass
-    readonly parentClassInterface: ParentClassInterface
-    readonly providerHolder: ProviderHolder
+    abstract readonly value: symbol
+    abstract readonly parentClass: ParentClass
+    abstract readonly parentClassInterface: ParentClassInterface
+    abstract readonly providerHolder: ProviderHolder
 
-    readonly subcomponentFactory: (values: number[]) => ChildSubcomponent
-    readonly scopedSubcomponentFactory: () => ScopedSubcomponent
-    readonly aliasedSubcomponentFactory: ChildSubcomponentFactory
-    readonly builtInTypeSubcomponentFactory: SubcomponentFactory<typeof ChildSubcomponent>
+    abstract readonly subcomponentFactory: (values: number[]) => ChildSubcomponent
+    abstract readonly scopedSubcomponentFactory: () => ScopedSubcomponent
+    abstract readonly aliasedSubcomponentFactory: ChildSubcomponentFactory
+    abstract readonly builtInTypeSubcomponentFactory: SubcomponentFactory<typeof ChildSubcomponent>
 }
 
-const parentComponent = new ParentComponent(new ChildComponent(), {value: Symbol.for("value")}, "bound")
+const parentComponent = createComponent<typeof ParentComponent>(new ChildComponent(), {value: Symbol.for("value")}, "bound")
 
 @Module
 abstract class ProviderModule {
@@ -409,12 +410,12 @@ abstract class ProviderModule {
 }
 
 @Component({modules: [ProviderModule]})
-class ProviderComponent {
+abstract class ProviderComponent {
 
-    readonly providedOnlyProvider: Provider<ProvidedOnly>
+    abstract readonly providedOnlyProvider: Provider<ProvidedOnly>
 }
 
-const providerComponent = new ProviderComponent()
+const providerComponent = createComponent<typeof ProviderComponent>()
 
 const MyQualifier = Qualifier()
 
@@ -447,16 +448,16 @@ class IncludesModule {
 }
 
 @Component({modules: [IncludesModule]})
-class IncludesComponent {
+abstract class IncludesComponent {
 
-    readonly includedValue: number
+    abstract readonly includedValue: number
 
-    @Named("my name") readonly namedValue: number
+    @Named("my name") abstract readonly namedValue: number
 
-    @MyQualifier readonly qualifiedValue: number
+    @MyQualifier abstract readonly qualifiedValue: number
 }
 
-const includesComponent = new IncludesComponent()
+const includesComponent = createComponent<typeof IncludesComponent>()
 
 @Inject
 class ProvidedOptional {
@@ -477,13 +478,13 @@ class OptionalModule {
 }
 
 @Component({modules: [OptionalModule]})
-class OptionalComponent {
+abstract class OptionalComponent {
 
-    readonly providedOptional?: ProvidedOptional
-    readonly missingOptional?: MissingOptional
+    abstract readonly providedOptional?: ProvidedOptional
+    abstract readonly missingOptional?: MissingOptional
 }
 
-const optionalComponent = new OptionalComponent()
+const optionalComponent = createComponent<typeof OptionalComponent>()
 
 @Module
 abstract class MultibindingSetSubcomponentModule {
@@ -636,17 +637,17 @@ class MultibindingTypeImpl {
 }
 
 @Component({modules: [MultibindingSetModule, MultibindingMapModule], subcomponents: [MultibindingSetSubcomponent]})
-class MultibindingsComponent {
+abstract class MultibindingsComponent {
 
-    readonly numberSet: ReadonlySet<number>
-    readonly boundSet: ReadonlySet<MultibindingType>
-    @MyQualifier readonly qualifiedSet: ReadonlySet<number>
-    @MyQualifier readonly qualifiedMap: ReadonlyMap<string, number>
+    abstract readonly numberSet: ReadonlySet<number>
+    abstract readonly boundSet: ReadonlySet<MultibindingType>
+    @MyQualifier abstract readonly qualifiedSet: ReadonlySet<number>
+    @MyQualifier abstract readonly qualifiedMap: ReadonlyMap<string, number>
 
-    readonly numberMap: ReadonlyMap<string, number>
-    readonly boundMap: ReadonlyMap<string, MultibindingType>
+    abstract readonly numberMap: ReadonlyMap<string, number>
+    abstract readonly boundMap: ReadonlyMap<string, MultibindingType>
 
-    readonly subcomponentFactory: SubcomponentFactory<typeof MultibindingSetSubcomponent>
+    abstract readonly subcomponentFactory: SubcomponentFactory<typeof MultibindingSetSubcomponent>
 }
 
-const multibindingComponent = new MultibindingsComponent()
+const multibindingComponent = createComponent<typeof MultibindingsComponent>()

--- a/integration/test/InjectTest.ts
+++ b/integration/test/InjectTest.ts
@@ -55,6 +55,9 @@ describe("Injection", () => {
         it("type literal properties are bound", () => {
             assert.strictEqual(parentComponent.value, Symbol.for("value"))
         })
+        it("implemented properties are not overriden", () => {
+            assert.ok(parentComponent.implementedProperty)
+        })
     })
     describe("Providers", () => {
         it("provider type provides instance of Provider", () => {
@@ -387,12 +390,18 @@ interface ParentClassInterface {
     readonly child: ChildClass
 }
 
-@Component({generatedClassName: "CustomComponentName", modules: [ParentModule], subcomponents: [ChildSubcomponent, ScopedSubcomponent]})
-abstract class ParentComponent {
-
-    constructor(child: ChildComponent, typeLiteralChild: {value: symbol}, @BindsInstance public boundString: string) { }
-
+abstract class InheritedClass {
     abstract readonly value: symbol
+    abstract readonly implementedProperty: boolean
+}
+
+@Component({generatedClassName: "CustomComponentName", modules: [ParentModule], subcomponents: [ChildSubcomponent, ScopedSubcomponent]})
+abstract class ParentComponent extends InheritedClass {
+
+    constructor(child: ChildComponent, typeLiteralChild: {value: symbol}, @BindsInstance public boundString: string) {
+        super()
+    }
+
     abstract readonly parentClass: ParentClass
     abstract readonly parentClassInterface: ParentClassInterface
     abstract readonly providerHolder: ProviderHolder
@@ -401,6 +410,8 @@ abstract class ParentComponent {
     abstract readonly scopedSubcomponentFactory: () => ScopedSubcomponent
     abstract readonly aliasedSubcomponentFactory: ChildSubcomponentFactory
     abstract readonly builtInTypeSubcomponentFactory: SubcomponentFactory<typeof ChildSubcomponent>
+
+    override readonly implementedProperty = true
 }
 
 const parentComponent = createComponent<typeof ParentComponent>(new ChildComponent(), {value: Symbol.for("value")}, "bound")

--- a/integration/test/InjectTest.ts
+++ b/integration/test/InjectTest.ts
@@ -17,6 +17,7 @@ import {
     IntoMap,
     MapKey,
     createComponent,
+    getConstructor,
 } from "karambit-inject"
 
 describe("Injection", () => {
@@ -414,7 +415,8 @@ abstract class ParentComponent extends InheritedClass {
     override readonly implementedProperty = true
 }
 
-const parentComponent = createComponent<typeof ParentComponent>(new ChildComponent(), {value: Symbol.for("value")}, "bound")
+const ParentComponentConstructor = getConstructor(ParentComponent)
+const parentComponent = new ParentComponentConstructor(new ChildComponent(), {value: Symbol.for("value")}, "bound")
 
 @Module
 abstract class ProviderModule {

--- a/integration/test/InjectTest.ts
+++ b/integration/test/InjectTest.ts
@@ -311,7 +311,7 @@ abstract class GrandChildSubcomponent {
 
     protected constructor(@BindsInstance dep: GrandChildDependency) { }
 
-    readonly grandChildClass: GrandChildClass
+    abstract readonly grandChildClass: GrandChildClass
 }
 
 interface ChildSubcomponentInterface {
@@ -325,9 +325,9 @@ abstract class ChildSubcomponent implements ChildSubcomponentInterface {
 
     constructor(@BindsInstance values: number[]) { }
 
-    readonly sum: number
-    readonly parentClass: ParentClass
-    readonly grandChildSubcomponentFactory: (dep: GrandChildDependency) => GrandChildSubcomponent
+    abstract readonly sum: number
+    abstract readonly parentClass: ParentClass
+    abstract readonly grandChildSubcomponentFactory: (dep: GrandChildDependency) => GrandChildSubcomponent
 }
 type ChildSubcomponentFactory = (values: number[]) => ChildSubcomponentInterface
 
@@ -355,8 +355,8 @@ class ScopedSubcomponentModule {
 @TestSubcomponentScope
 abstract class ScopedSubcomponent {
 
-    readonly scopedClass: ScopedSubcomponentClass
-    readonly scopedInterface: ScopedSubcomponentInterface
+    abstract readonly scopedClass: ScopedSubcomponentClass
+    abstract readonly scopedInterface: ScopedSubcomponentInterface
 }
 
 interface ParentInterface { }
@@ -506,8 +506,8 @@ abstract class MultibindingSetSubcomponentModule {
 @Subcomponent({modules: [MultibindingSetSubcomponentModule]})
 abstract class MultibindingSetSubcomponent {
 
-    readonly numberSetExtension: ReadonlySet<number>
-    readonly numberMapExtension: ReadonlyMap<string, number>
+    abstract readonly numberSetExtension: ReadonlySet<number>
+    abstract readonly numberMapExtension: ReadonlyMap<string, number>
 }
 
 interface ThreeHolder {

--- a/integration/test/InjectTest.ts
+++ b/integration/test/InjectTest.ts
@@ -189,6 +189,11 @@ describe("Injection", () => {
             assert.strictEqual(multibindingComponent.subcomponentFactory().numberMapExtension.get("four"), 4)
         })
     })
+    describe("Configuration", () => {
+        it("Component has custom name", () => {
+            assert.strictEqual(parentComponent.constructor.name, "CustomComponentName")
+        })
+    })
 })
 
 const TestScope = Scope()
@@ -382,7 +387,7 @@ interface ParentClassInterface {
     readonly child: ChildClass
 }
 
-@Component({modules: [ParentModule], subcomponents: [ChildSubcomponent, ScopedSubcomponent]})
+@Component({generatedClassName: "CustomComponentName", modules: [ParentModule], subcomponents: [ChildSubcomponent, ScopedSubcomponent]})
 abstract class ParentComponent {
 
     constructor(child: ChildComponent, typeLiteralChild: {value: symbol}, @BindsInstance public boundString: string) { }

--- a/samples/hello_world/src/index.ts
+++ b/samples/hello_world/src/index.ts
@@ -1,12 +1,12 @@
-import {Inject, Module, Provides, Component} from "karambit-inject"
+import {Inject, Module, Provides, Component, createComponent} from "karambit-inject"
 
 @Inject
 class Greeter {
 
-    constructor(private readonly target: string) { }
+    constructor(private readonly greeting: string) { }
 
     greet(): string {
-        return `Hello, ${this.target}!`
+        return `${this.greeting}, World!`
     }
 }
 
@@ -14,16 +14,16 @@ class Greeter {
 abstract class HelloWorldModule {
 
     @Provides
-    static provideGreetingTarget(): string {
-        return "World"
+    static provideGreeting(): string {
+        return "Hello"
     }
 }
 
 @Component({modules: [HelloWorldModule]})
-class HelloWorldComponent {
+abstract class HelloWorldComponent {
 
-    readonly greeter: Greeter
+    abstract readonly greeter: Greeter
 }
 
-const component = new HelloWorldComponent()
+const component = createComponent<typeof HelloWorldComponent>()
 console.log(component.greeter.greet())

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -9,17 +9,18 @@ import {
     Subcomponent,
     SubcomponentFactory
 } from "karambit-inject"
-import {InjectNodeDetector} from "./InjectNodeDetector"
-import {InjectConstructorExporter} from "./InjectConstructorExporter"
-import {ComponentVisitor} from "./ComponentVisitor"
-import {Importer} from "./Importer"
 import {ComponentGenerationScope, ProgramScope, SourceFileScope} from "./Scopes"
-import {
+import type {InjectNodeDetector} from "./InjectNodeDetector"
+import type {InjectConstructorExporter} from "./InjectConstructorExporter"
+import type {ComponentVisitor} from "./ComponentVisitor"
+import type {Importer} from "./Importer"
+import type {
     ComponentGenerator,
     ComponentGeneratorDependencies,
     ComponentGeneratorDependenciesFactory
 } from "./ComponentGenerator"
 import type {KarambitTransformOptions} from "./karambit"
+import type {CreateComponentTransformer} from "./CreateComponentTransformer"
 
 @Subcomponent
 @ComponentGenerationScope
@@ -39,6 +40,7 @@ abstract class SourceFileModule {
         componentVisitor: ComponentVisitor,
         nodeDetector: InjectNodeDetector,
         importer: Importer,
+        createComponentTransformer: CreateComponentTransformer,
         ctx: ts.TransformationContext,
     ): ts.Transformer<ts.SourceFile>[] {
         return [
@@ -46,6 +48,7 @@ abstract class SourceFileModule {
             componentVisitor.visitComponents,
             node => nodeDetector.eraseInjectRuntime(node, ctx),
             importer.addImportsToSourceFile,
+            createComponentTransformer.transform,
         ]
     }
 
@@ -80,6 +83,12 @@ abstract class ProgramModule {
     @Reusable
     static provideTypeChecker(program: ts.Program): ts.TypeChecker {
         return program.getTypeChecker()
+    }
+
+    @Provides
+    @ProgramScope
+    static provideComponentIdentifiers(): Map<ts.Type, ts.Identifier> {
+        return new Map()
     }
 }
 

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -38,17 +38,17 @@ abstract class SourceFileModule {
     static provideTransformers(
         classExporter: InjectConstructorExporter,
         componentVisitor: ComponentVisitor,
+        createComponentTransformer: CreateComponentTransformer,
         nodeDetector: InjectNodeDetector,
         importer: Importer,
-        createComponentTransformer: CreateComponentTransformer,
         ctx: ts.TransformationContext,
     ): ts.Transformer<ts.SourceFile>[] {
         return [
             classExporter.exportProviders,
             componentVisitor.visitComponents,
+            createComponentTransformer.transform,
             node => nodeDetector.eraseInjectRuntime(node, ctx),
             importer.addImportsToSourceFile,
-            createComponentTransformer.transform,
         ]
     }
 

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -46,7 +46,8 @@ abstract class SourceFileModule {
         return [
             classExporter.exportProviders,
             componentVisitor.visitComponents,
-            createComponentTransformer.transform,
+            createComponentTransformer.replaceCreateComponent,
+            createComponentTransformer.replaceGetConstructor,
             node => nodeDetector.eraseInjectRuntime(node, ctx),
             importer.addImportsToSourceFile,
         ]

--- a/src/ComponentDeclarationBuilder.ts
+++ b/src/ComponentDeclarationBuilder.ts
@@ -32,10 +32,10 @@ export class ComponentDeclarationBuilder {
         this.getParamExpression = this.getParamExpression.bind(this)
     }
 
-    declareComponent(options: {componentType: ts.Type, declaration: ts.ClassDeclaration, constructorParams: ConstructorParameter[], members: ts.ClassElement[]}): ts.ClassDeclaration {
+    declareComponent(options: {componentType: ts.Type, declaration: ts.ClassDeclaration, constructorParams: ConstructorParameter[], members: ts.ClassElement[], preferredClassName?: string}): ts.ClassDeclaration {
         return ts.factory.createClassDeclaration(
             [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
-            this.nameGenerator.getComponentIdentifier(options.componentType),
+            this.nameGenerator.getComponentIdentifier(options.componentType, options.preferredClassName),
             [],
             [ts.factory.createHeritageClause(
                 ts.SyntaxKind.ExtendsKeyword,

--- a/src/ComponentDeclarationBuilder.ts
+++ b/src/ComponentDeclarationBuilder.ts
@@ -72,7 +72,7 @@ export class ComponentDeclarationBuilder {
     }
 
     updateComponentMember(member: ts.ClassElement): ts.Node | undefined {
-        if (ts.isPropertyDeclaration(member) && !member.initializer) {
+        if (ts.isPropertyDeclaration(member) && member.modifiers?.some(it => it.kind === ts.SyntaxKind.AbstractKeyword)) {
             const type = createQualifiedType({
                 type: this.typeChecker.getTypeAtLocation(member.type ?? member),
                 qualifier: this.nodeDetector.getQualifier(member)

--- a/src/ComponentDeclarationBuilder.ts
+++ b/src/ComponentDeclarationBuilder.ts
@@ -505,12 +505,7 @@ export class ComponentDeclarationBuilder {
     private getExpressionForDeclaration(node: ts.Declaration): ts.Expression {
         const type = this.typeChecker.getTypeAtLocation(node)!
         const symbol = type.getSymbol()!
-        if (this.sourceFile === node.getSourceFile()) return ts.factory.createIdentifier(symbol.getName())
-
-        return ts.factory.createPropertyAccessExpression(
-            ts.factory.getGeneratedNameForNode(this.importer.getImportForSymbol(symbol)),
-            ts.factory.createIdentifier(symbol.getName())
-        )
+        return this.importer.getExpressionForDeclaration(symbol, node.getSourceFile())
     }
 
     accessParentGetter(type: QualifiedType): ts.Expression {

--- a/src/ComponentDeclarationBuilder.ts
+++ b/src/ComponentDeclarationBuilder.ts
@@ -32,11 +32,11 @@ export class ComponentDeclarationBuilder {
         this.getParamExpression = this.getParamExpression.bind(this)
     }
 
-    declareComponent(options: {componentType: QualifiedType, declaration: ts.ClassDeclaration, constructorParams: ConstructorParameter[], members: ts.ClassElement[]}): ts.ClassDeclaration {
+    declareComponent(options: {componentType: ts.Type, declaration: ts.ClassDeclaration, constructorParams: ConstructorParameter[], members: ts.ClassElement[]}): ts.ClassDeclaration {
         return ts.factory.createClassDeclaration(
-            undefined,
+            [ts.factory.createToken(ts.SyntaxKind.ExportKeyword)],
             this.nameGenerator.getComponentIdentifier(options.componentType),
-            undefined,
+            [],
             [ts.factory.createHeritageClause(
                 ts.SyntaxKind.ExtendsKeyword,
                 [ts.factory.createExpressionWithTypeArguments(

--- a/src/ComponentGenerator.ts
+++ b/src/ComponentGenerator.ts
@@ -290,7 +290,7 @@ export class ComponentGenerator {
                 .distinctBy(([type, provider]) => isSubcomponentFactory(provider) ? provider.subcomponentType : type)
         )
         return [component, builder.declareComponent({
-            componentType: createQualifiedType({type: componentType, discriminator: null}),
+            componentType: componentType,
             declaration: component,
             constructorParams: this.constructorHelper.getConstructorParamsForDeclaration(component) ?? [],
             members: [

--- a/src/ComponentGenerator.ts
+++ b/src/ComponentGenerator.ts
@@ -291,6 +291,7 @@ export class ComponentGenerator {
         )
         return [component, builder.declareComponent({
             componentType: componentType,
+            preferredClassName: this.moduleLocator.getGeneratedClassName(componentDecorator),
             declaration: component,
             constructorParams: this.constructorHelper.getConstructorParamsForDeclaration(component) ?? [],
             members: [

--- a/src/ComponentGenerator.ts
+++ b/src/ComponentGenerator.ts
@@ -114,7 +114,7 @@ export class ComponentGenerator {
         return this.propertyExtractor.getDeclaredPropertiesForType(componentType)
             .filter(property => property.initializer === undefined)
             .map(property => {
-                if (!property.modifiers || !property.modifiers.some(it => it.kind === ts.SyntaxKind.ReadonlyKeyword)) {
+                if (property.modifiers && property.modifiers.some(it => it.kind === ts.SyntaxKind.AbstractKeyword) && !property.modifiers.some(it => it.kind === ts.SyntaxKind.ReadonlyKeyword)) {
                     this.errorReporter.reportComponentPropertyMustBeReadOnly(property)
                 }
                 return {

--- a/src/ComponentGenerator.ts
+++ b/src/ComponentGenerator.ts
@@ -113,6 +113,9 @@ export class ComponentGenerator {
     }
 
     private getRootDependencies(componentType: ts.Type): RootDependency[] {
+        const unimplementedMethods = this.propertyExtractor.getUnimplementedAbstractMethods(componentType)
+        // TODO: Eventually we can implement some simple methods. For now fail on any unimplemented methods.
+        if (unimplementedMethods.length > 0) this.errorReporter.reportParseFailed("Component has method(s) that Karambit cannot implement! A Component should not have any abstract methods.", unimplementedMethods[0])
         return this.propertyExtractor.getUnimplementedAbstractProperties(componentType)
             .map(property => {
                 if (property.modifiers && !property.modifiers.some(it => it.kind === ts.SyntaxKind.ReadonlyKeyword)) {

--- a/src/ComponentVisitor.ts
+++ b/src/ComponentVisitor.ts
@@ -16,7 +16,7 @@ export class ComponentVisitor {
     }
 
     visitComponents(sourceFile: ts.SourceFile): ts.SourceFile
-    visitComponents(node: ts.Node): ts.Node {
+    visitComponents(node: ts.Node): ts.Node | ts.Node[] {
         if (ts.isClassDeclaration(node) && node.modifiers?.some(this.nodeDetector.isComponentDecorator)) {
             const generatorDeps = this.componentGeneratorDependenciesFactory(node)
             return generatorDeps.generator.updateComponent()

--- a/src/CreateComponentTransformer.ts
+++ b/src/CreateComponentTransformer.ts
@@ -1,6 +1,7 @@
 import {Inject, Reusable} from "karambit-inject"
 import * as ts from "typescript"
 import {InjectNodeDetector} from "./InjectNodeDetector"
+import {Importer} from "./Importer"
 
 @Inject
 @Reusable
@@ -11,6 +12,7 @@ export class CreateComponentTransformer {
         private readonly nodeDetector: InjectNodeDetector,
         private readonly componentIdentifiers: Map<ts.Type, ts.Identifier>,
         private readonly typeChecker: ts.TypeChecker,
+        private readonly importer: Importer,
     ) {
         this.transform = this.transform.bind(this)
     }
@@ -21,7 +23,15 @@ export class CreateComponentTransformer {
         if (componentType) {
             const identifier = this.componentIdentifiers.get(componentType)
             if (!identifier) throw new Error(`Cannot create instance of ${this.typeChecker.typeToString(componentType)}! Is the type decorated with @Component?`)
-            return ts.factory.createNewExpression(identifier, undefined, node.arguments.map(it => ts.visitNode(it, this.transform)))
+            const symbol = componentType.getSymbol()
+            if (!symbol) throw new Error(`Couldn't find symbol of type ${this.typeChecker.typeToString(componentType)}!`)
+            const declaration = symbol.valueDeclaration
+            if (!declaration) throw new Error(`Couldn't find declaration of type ${this.typeChecker.typeToString(componentType)}!`)
+            return ts.factory.createNewExpression(
+                this.importer.getExpressionForDeclaration(componentType.symbol, declaration.getSourceFile(), identifier),
+                undefined,
+                node.arguments.map(it => ts.visitNode(it, this.transform))
+            )
         } else {
             return ts.visitEachChild(node, this.transform, this.context)
         }

--- a/src/CreateComponentTransformer.ts
+++ b/src/CreateComponentTransformer.ts
@@ -1,0 +1,29 @@
+import {Inject, Reusable} from "karambit-inject"
+import * as ts from "typescript"
+import {InjectNodeDetector} from "./InjectNodeDetector"
+
+@Inject
+@Reusable
+export class CreateComponentTransformer {
+
+    constructor(
+        private readonly context: ts.TransformationContext,
+        private readonly nodeDetector: InjectNodeDetector,
+        private readonly componentIdentifiers: Map<ts.Type, ts.Identifier>,
+        private readonly typeChecker: ts.TypeChecker,
+    ) {
+        this.transform = this.transform.bind(this)
+    }
+
+    transform(sourceFile: ts.SourceFile): ts.SourceFile
+    transform<T>(node: ts.Node): ts.Node {
+        const componentType = ts.isCallExpression(node) && this.nodeDetector.isCreateComponentCall(node)
+        if (componentType) {
+            const identifier = this.componentIdentifiers.get(componentType)
+            if (!identifier) throw new Error(`Cannot create instance of ${this.typeChecker.typeToString(componentType)}! Is the type decorated with @Component?`)
+            return ts.factory.createNewExpression(identifier, undefined, node.arguments.map(it => ts.visitNode(it, this.transform)))
+        } else {
+            return ts.visitEachChild(node, this.transform, this.context)
+        }
+    }
+}

--- a/src/ErrorReporter.ts
+++ b/src/ErrorReporter.ts
@@ -50,7 +50,7 @@ export class ErrorReporter {
     reportComponentPropertyMustBeReadOnly(property: ts.Node): never {
         ErrorReporter.fail(
             KarambitErrorScope.PARSE,
-            `Generated component properties must be read-only!\n\n${nodeForDisplay(property)}\n`,
+            `Abstract component properties must be read-only!\n\n${nodeForDisplay(property)}\n`,
             this.component
         )
     }

--- a/src/ErrorReporter.ts
+++ b/src/ErrorReporter.ts
@@ -36,7 +36,7 @@ export class ErrorReporter {
 
     constructor(
         private readonly typeChecker: ts.TypeChecker,
-        private readonly component: ts.ClassDeclaration,
+        private readonly component?: ts.ClassDeclaration,
     ) { }
 
     reportCompileTimeConstantRequired(context: ts.Node, identifierName: string): never {

--- a/src/Importer.ts
+++ b/src/Importer.ts
@@ -31,6 +31,15 @@ export class Importer {
         )
     }
 
+    getExpressionForDeclaration(symbol: ts.Symbol, sourceFile: ts.SourceFile, identifier?: ts.Identifier): ts.Expression {
+        if (this.sourceFile === sourceFile) return identifier ?? ts.factory.createIdentifier(symbol.getName())
+
+        return ts.factory.createPropertyAccessExpression(
+            ts.factory.getGeneratedNameForNode(this.getImportForSymbol(symbol)),
+            identifier ?? ts.factory.createIdentifier(symbol.getName())
+        )
+    }
+
     private createImportForSymbol(symbol: ts.Symbol, importPath: string): ts.ImportDeclaration {
         const myPath = this.sourceFile.fileName.replace(/[^/]+$/, "")
         const relativePath = Path.relative(myPath, importPath).replace(/\.ts$/, "")

--- a/src/InjectNodeDetector.ts
+++ b/src/InjectNodeDetector.ts
@@ -48,6 +48,15 @@ export class InjectNodeDetector {
         }
     }
 
+    isGetConstructorCall(expression: ts.CallExpression): ts.Type | undefined {
+        if (ts.isIdentifier(expression.expression) && this.getKarambitNodeName(expression) === "getConstructor") {
+            const symbol = this.typeChecker.getSymbolAtLocation(expression.arguments[0])
+            const type = symbol?.valueDeclaration && this.typeChecker.getTypeAtLocation(symbol.valueDeclaration)
+            if (type) return type
+            this.errorReporter.reportParseFailed("Unable to parse getComponent call!", expression)
+        }
+    }
+
     isScopeDecorator(decorator: ts.Node): decorator is ts.Decorator {
         if (!ts.isDecorator(decorator)) return false
         const type = this.typeChecker.getTypeAtLocation(decorator.expression)

--- a/src/InjectNodeDetector.ts
+++ b/src/InjectNodeDetector.ts
@@ -17,7 +17,11 @@ interface Decorated {
 @Reusable
 export class InjectNodeDetector {
 
-    constructor(private readonly typeChecker: ts.TypeChecker, private readonly karambitOptions: KarambitTransformOptions) {
+    constructor(
+        private readonly typeChecker: ts.TypeChecker,
+        private readonly karambitOptions: KarambitTransformOptions,
+        private readonly errorReporter: ErrorReporter,
+    ) {
         this.isCreateComponentCall = this.isCreateComponentCall.bind(this)
         this.isScopeDecorator = this.isScopeDecorator.bind(this)
         this.isScope = this.isScope.bind(this)
@@ -168,7 +172,7 @@ export class InjectNodeDetector {
             const argument = decorator.expression.arguments[0]
             if (!argument) return undefined
 
-            if (!this.isCompileTimeConstant(argument)) throw new Error("@MapKey argument must be a literal!")
+            if (!this.isCompileTimeConstant(argument)) this.errorReporter.reportParseFailed("@MapKey argument must be a literal!", decorator)
 
             const keyTypeNode = decorator.expression.typeArguments
                 ? decorator.expression.typeArguments[0]

--- a/src/NameGenerator.ts
+++ b/src/NameGenerator.ts
@@ -39,7 +39,6 @@ export class NameGenerator {
     }
 
     getPropertyIdentifierForParameter(param: ts.ParameterDeclaration): ts.Identifier {
-        if (param.modifiers && param.modifiers.length > 0) return ts.factory.createIdentifier(param.name.getText())
         const existingName = this.paramPropertyNames.get(param)
         if (existingName) return existingName
 

--- a/src/NameGenerator.ts
+++ b/src/NameGenerator.ts
@@ -18,12 +18,12 @@ export class NameGenerator {
 
     readonly parentName: ts.Identifier = ts.factory.createUniqueName("parent")
 
-    getComponentIdentifier(type: ts.Type): ts.Identifier {
+    getComponentIdentifier(type: ts.Type, preferredName?: string): ts.Identifier {
         const existingName = this.componentIdentifiers.get(type)
         if (existingName) return existingName
 
         // for some reason, createUniqueName doesn't work with the export keyword here...?
-        const newName = ts.factory.createIdentifier(`Karambit${this.getValidIdentifier(type)}`)
+        const newName = ts.factory.createIdentifier(preferredName ?? `Karambit${this.getValidIdentifier(type)}`)
         this.componentIdentifiers.set(type, newName)
         return newName
     }

--- a/src/NameGenerator.ts
+++ b/src/NameGenerator.ts
@@ -11,11 +11,22 @@ export class NameGenerator {
         private readonly typeChecker: ts.TypeChecker
     ) { }
 
+    private componentNames = new Map<QualifiedType, ts.Identifier>()
     private propertyNames = new Map<QualifiedType, ts.Identifier | ts.PrivateIdentifier>()
     private paramPropertyNames = new Map<ts.ParameterDeclaration, ts.Identifier>()
     private getterNames = new Map<QualifiedType, ts.Identifier | ts.PrivateIdentifier>()
 
     readonly parentName: ts.Identifier = ts.factory.createUniqueName("parent")
+
+    getComponentIdentifier(type: QualifiedType): ts.Identifier {
+        const existingName = this.componentNames.get(type)
+        if (existingName) return existingName
+
+        const identifierText = this.getValidIdentifier(type.type)
+        const newName = ts.factory.createUniqueName(`Karambit${identifierText}`)
+        this.componentNames.set(type, newName)
+        return newName
+    }
 
     getPropertyIdentifier(type: QualifiedType): ts.Identifier | ts.PrivateIdentifier {
         const existingName = this.propertyNames.get(type)

--- a/src/NameGenerator.ts
+++ b/src/NameGenerator.ts
@@ -23,7 +23,7 @@ export class NameGenerator {
         if (existingName) return existingName
 
         // for some reason, createUniqueName doesn't work with the export keyword here...?
-        const newName = ts.factory.createIdentifier(preferredName ?? `Karambit${this.getValidIdentifier(type)}`)
+        const newName = ts.factory.createIdentifier(preferredName ?? `Karambit${capitalize(this.getValidIdentifier(type))}`)
         this.componentIdentifiers.set(type, newName)
         return newName
     }

--- a/src/NameGenerator.ts
+++ b/src/NameGenerator.ts
@@ -8,23 +8,23 @@ import {SourceFileScope} from "./Scopes"
 export class NameGenerator {
 
     constructor(
-        private readonly typeChecker: ts.TypeChecker
+        private readonly typeChecker: ts.TypeChecker,
+        private readonly componentIdentifiers: Map<ts.Type, ts.Identifier>,
     ) { }
 
-    private componentNames = new Map<QualifiedType, ts.Identifier>()
     private propertyNames = new Map<QualifiedType, ts.Identifier | ts.PrivateIdentifier>()
     private paramPropertyNames = new Map<ts.ParameterDeclaration, ts.Identifier>()
     private getterNames = new Map<QualifiedType, ts.Identifier | ts.PrivateIdentifier>()
 
     readonly parentName: ts.Identifier = ts.factory.createUniqueName("parent")
 
-    getComponentIdentifier(type: QualifiedType): ts.Identifier {
-        const existingName = this.componentNames.get(type)
+    getComponentIdentifier(type: ts.Type): ts.Identifier {
+        const existingName = this.componentIdentifiers.get(type)
         if (existingName) return existingName
 
-        const identifierText = this.getValidIdentifier(type.type)
-        const newName = ts.factory.createUniqueName(`Karambit${identifierText}`)
-        this.componentNames.set(type, newName)
+        // for some reason, createUniqueName doesn't work with the export keyword here...?
+        const newName = ts.factory.createIdentifier(`Karambit${this.getValidIdentifier(type)}`)
+        this.componentIdentifiers.set(type, newName)
         return newName
     }
 

--- a/src/SubcomponentFactoryLocator.ts
+++ b/src/SubcomponentFactoryLocator.ts
@@ -79,9 +79,11 @@ export class SubcomponentFactoryLocator {
         const constructorParams = this.constructorHelper.getConstructorParamsForDeclaration(declaration)
         if (!constructorParams) return undefined
 
+        const subcomponentType = this.typeChecker.getTypeAtLocation(declaration)
+
         return {
             providerType: ProviderType.SUBCOMPONENT_FACTORY,
-            subcomponentType: createQualifiedType({type: aliasedType, qualifier: internalQualifier}),
+            subcomponentType: createQualifiedType({type: subcomponentType, qualifier: internalQualifier}),
             type: createQualifiedType({type}),
             constructorParams,
             declaration,

--- a/src/karambit.ts
+++ b/src/karambit.ts
@@ -96,6 +96,11 @@ export function Named(name: string): NamedQualifierDecorator {
     ErrorReporter.reportCodeNotTransformed()
 }
 
+// noinspection JSUnusedLocalSymbols
+export function createComponent<T extends abstract new (...args: ConstructorParameters<T>) => InstanceType<T>>(...args: ConstructorParameters<T>): InstanceType<T> {
+    ErrorReporter.reportCodeNotTransformed()
+}
+
 export interface ScopeDecorator {
     <T>(target: any, propertyKey?: string | symbol, descriptor?: TypedPropertyDescriptor<T>): any | void
 }

--- a/src/karambit.ts
+++ b/src/karambit.ts
@@ -9,7 +9,9 @@ interface ComponentLikeInfo {
     readonly subcomponents?: unknown[]
 }
 
-interface ComponentInfo extends ComponentLikeInfo { }
+interface ComponentInfo extends ComponentLikeInfo {
+    generatedClassName?: string
+}
 
 export function Component(info: ComponentInfo): ClassDecorator
 export function Component(target: unknown): void

--- a/src/karambit.ts
+++ b/src/karambit.ts
@@ -98,8 +98,15 @@ export function Named(name: string): NamedQualifierDecorator {
     ErrorReporter.reportCodeNotTransformed()
 }
 
+type ConstructorType<T extends abstract new (...args: ConstructorParameters<T>) => InstanceType<T>> = abstract new (...args: ConstructorParameters<T>) => InstanceType<T>
+
 // noinspection JSUnusedLocalSymbols
-export function createComponent<T extends abstract new (...args: ConstructorParameters<T>) => InstanceType<T>>(...args: ConstructorParameters<T>): InstanceType<T> {
+export function createComponent<T extends ConstructorType<T>>(...args: ConstructorParameters<T>): InstanceType<T> {
+    ErrorReporter.reportCodeNotTransformed()
+}
+
+// noinspection JSUnusedLocalSymbols
+export function getConstructor<T extends ConstructorType<T>>(type: T): new (...args: ConstructorParameters<T>) => InstanceType<T> {
     ErrorReporter.reportCodeNotTransformed()
 }
 

--- a/src/karambit.ts
+++ b/src/karambit.ts
@@ -100,11 +100,20 @@ export function Named(name: string): NamedQualifierDecorator {
 
 type ConstructorType<T extends abstract new (...args: ConstructorParameters<T>) => InstanceType<T>> = abstract new (...args: ConstructorParameters<T>) => InstanceType<T>
 
+/**
+ * Create a Component instance. Used to access a generated Component from the same compilation unit.
+ * @param args the constructor arguments of the component.
+ */
 // noinspection JSUnusedLocalSymbols
 export function createComponent<T extends ConstructorType<T>>(...args: ConstructorParameters<T>): InstanceType<T> {
     ErrorReporter.reportCodeNotTransformed()
 }
 
+/**
+ * Get a reference to the generated Component constructor.
+ * Used to access a generated Component from the same compilation unit.
+ * @param type the constructor of the type decorated with @{@link Component}
+ */
 // noinspection JSUnusedLocalSymbols
 export function getConstructor<T extends ConstructorType<T>>(type: T): new (...args: ConstructorParameters<T>) => InstanceType<T> {
     ErrorReporter.reportCodeNotTransformed()


### PR DESCRIPTION
I don't like that Karambit modifies classes defined by the end user. Instead, it now generates a subclass instead.

Classes marked `@​Component` must now also be marked `abstract`. Karambit will now only generate properties that are marked `abstract`.